### PR TITLE
Add support for Llama2, Palm, Cohere, Replicate Models - using litellm

### DIFF
--- a/autochain/models/chat_openai.py
+++ b/autochain/models/chat_openai.py
@@ -173,20 +173,21 @@ class ChatOpenAI(BaseLanguageModel):
         openai_api_base = os.environ.get("OPENAI_API_BASE", None)
         try:
             import openai
+            import litellm
 
         except ImportError:
             raise ValueError(
                 "Could not import openai python package. "
                 "Please install it with `pip install openai`."
             )
-        values["api_key"] = openai.api_key = openai_api_key
-        values["api_type"] = openai.api_type = openai_api_type
+        values["api_key"] = litellm.api_key = openai_api_key
+        values["api_type"] = litellm.api_type = openai_api_type
         if openai_api_base:
-            values["api_base"] = openai.api_base = openai_api_base
+            values["api_base"] = litellm.api_base = openai_api_base
         if openai_api_type == "azure":
-            values["azure_api_version"] = openai.api_version = os.environ.get("OPENAI_API_VERSION", "2023-05-15")
+            values["azure_api_version"] = litellm.api_version = os.environ.get("OPENAI_API_VERSION", "2023-05-15")
         try:
-            values["client"] = openai.ChatCompletion
+            values["client"] = litellm.completion
         except AttributeError:
             raise ValueError(
                 "`openai` has no `ChatCompletion` attribute, this is likely "

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ chromadb = ">=0.3.26"
 lancedb = {version = ">=0.1.16", optional = true}
 pandas = ">=2.0.2"
 openai = ">=0.27.8"
+litellm = ">=0.1.400"
 types-colorama = ">=0.4.15.11"
 pytest = "^7.3.2"
 redis = "^4.6.0"


### PR DESCRIPTION
This PR adds support for models from all the above mentioned providers using https://github.com/BerriAI/litellm/

Here's a sample of how it's used:

```python
from litellm import completion, acompletion

## set ENV variables
# ENV variables can be set in .env file, too. Example in .env.example
os.environ["OPENAI_API_KEY"] = "openai key"
os.environ["COHERE_API_KEY"] = "cohere key"

messages = [{ "content": "Hello, how are you?","role": "user"}]

# openai call
response = completion(model="gpt-3.5-turbo", messages=messages)

# llama2 call
model_name = "replicate/llama-2-70b-chat:2c1608e18606fad2812020dc541930f2d0495ce32eee50074220b87300bc16e1"
response = completion(model_name, messages)

# cohere call
response = completion("command-nightly", messages)

# anthropic call
response = completion(model="claude-instant-1", messages=messages)
```
