### PR TITLE
Open-source LLM from HuggingFace Agent Support for json output parsing  

### DIFF
--- a/autochain/agent/conversational_agent/conversational_agent.py
+++ b/autochain/agent/conversational_agent/conversational_agent.py
@@ -165,6 +165,7 @@ class ConversationalAgent(BaseAgent):
         tool_strings = "\n\n".join(
             [f"> {tool.name}: \n{tool.description}" for tool in self.tools]
         )
+
         inputs = {
             "tool_names": tool_names,
             "tools": tool_strings,
@@ -175,11 +176,14 @@ class ConversationalAgent(BaseAgent):
         final_prompt = self.format_prompt(
             self.prompt_template, intermediate_steps, **inputs
         )
+
         logger.info(f"\nPlanning Input: {final_prompt[0].content} \n")
 
         full_output: Generation = self.llm.generate(final_prompt).generations[0]
+
         agent_output: Union[AgentAction, AgentFinish] = self.output_parser.parse(
-            full_output.message
+            full_output.message,
+            self.llm
         )
 
         print(f"Planning output: \n{repr(full_output.message.content)}", Fore.YELLOW)

--- a/autochain/agent/conversational_agent/output_parser.py
+++ b/autochain/agent/conversational_agent/output_parser.py
@@ -5,13 +5,14 @@ from colorama import Fore
 
 from autochain.agent.message import BaseMessage
 from autochain.agent.structs import AgentAction, AgentFinish, AgentOutputParser
+from autochain.models.base import BaseLanguageModel
 from autochain.errors import OutputParserException
 from autochain.utils import print_with_color
 
 
 class ConvoJSONOutputParser(AgentOutputParser):
-    def parse(self, message: BaseMessage) -> Union[AgentAction, AgentFinish]:
-        response = self.load_json_output(message)
+    def parse(self, message: BaseMessage, llm: BaseLanguageModel) -> Union[AgentAction, AgentFinish]:
+        response = self.load_json_output(message, llm)
 
         action_name = response.get("tool", {}).get("name")
         action_args = response.get("tool", {}).get("args")

--- a/autochain/agent/structs.py
+++ b/autochain/agent/structs.py
@@ -1,17 +1,15 @@
 import json
-import re
 from abc import abstractmethod
 from typing import Union, Any, Dict, List
+from colorama import Fore
 
-from autochain.models.base import Generation
-
-from autochain.models.chat_openai import ChatOpenAI
 from autochain.models.base import BaseLanguageModel
 from pydantic import BaseModel
 
+from autochain.models.base import Generation
 from autochain.agent.message import BaseMessage, UserMessage
 from autochain.chain import constants
-from autochain.errors import OutputParserException
+from autochain.utils import print_with_color
 
 
 class AgentAction(BaseModel):
@@ -56,29 +54,87 @@ class AgentFinish(BaseModel):
 
 
 class AgentOutputParser(BaseModel):
-    @staticmethod
-    def load_json_output(message: BaseMessage, llm: BaseLanguageModel) -> Dict[str, Any]:
-        """If the message contains a json response, try to parse it into dictionary"""
-        text = message.content
-        clean_text = ""
 
+    def load_json_output(
+        self,
+        message: BaseMessage, 
+        llm: BaseLanguageModel,
+        max_retry=3
+    ) -> Dict[str, Any]:
+        """Try to parse JSON response from the message content."""
+        text = message.content
+        print('Message: ', message)
+        clean_text = self._extract_json_text(text)
+        print('Clean text: ', clean_text)
         try:
-            clean_text = text[text.index("{") : text.rindex("}") + 1].strip()
             response = json.loads(clean_text)
         except Exception:
-            message = [
-                UserMessage(
-                    content=f"""Fix the following json into correct format
+            print_with_color(
+                'Generating JSON format attempt FAILED! Trying Again...', 
+                Fore.RED
+            )
+            message = self._fix_message(clean_text)
+            print('Check Message: ', message)
+            full_output: Generation = llm.generate(message).generations[0]
+            print("TEST: ", full_output)
+            response = self._attempt_fix_and_generate(message, llm, max_retry, attempt=0)
+
+        return response
+    
+    @staticmethod
+    def _fix_message(clean_text: str) -> UserMessage:
+        message = [UserMessage(
+                    content=f"""
+                        Fix the following json into correct format
                         ```json
                         {clean_text}
                         ```
                         """
-                )
-            ]
-            full_output: Generation = llm.generate(message).generations[0]
-            response = json.loads(full_output.message.content)
+                )]
+        return message
+        
+    @staticmethod
+    def _extract_json_text(text: str) -> str:
+        """Extract JSON text from the input string."""
+        clean_text = ""
+        try:
+            clean_text = text[text.index("{") : text.rindex("}") + 1].strip()
+        except Exception:
+            clean_text = text
+        return clean_text
+    
+    def _attempt_fix_and_generate(
+        self,
+        message: BaseMessage, 
+        llm: BaseLanguageModel,
+        max_retry: int,
+        attempt: int
+    ) -> Dict[str, Any]:
+        
+        """Attempt to fix JSON format using model generation."""
+        if attempt >= max_retry:
+            raise ValueError(
+                """
+                Max retry reached. Model is unable to generate proper JSON output. 
+                Try with another Model!
+                """
+            )
 
-        return response
+        full_output: Generation = llm.generate([message]).generations[0]
+        print('model output: ', full_output)
+        try:
+            response = json.loads(full_output.message.content)
+            return response
+        except Exception:
+            print_with_color(
+                'Generating JSON format attempt FAILED! Trying Again...',
+                Fore.RED
+            )
+            clean_text = self._extract_json_text(full_output.message.content)
+            print("Clean Text: ", clean_text)
+            message = self._fix_message(clean_text)
+            print('Message: ', message)
+            return self._attempt_fix_and_generate(message, llm, max_retry, attempt=attempt + 1)
 
     @abstractmethod
     def parse(self, message: BaseMessage) -> Union[AgentAction, AgentFinish]:

--- a/autochain/agent/structs.py
+++ b/autochain/agent/structs.py
@@ -81,6 +81,14 @@ class AgentOutputParser(BaseModel):
     
     @staticmethod
     def _fix_message(clean_text: str) -> UserMessage:
+        '''
+        If the response from model is not proper, this function should
+        iteratively construct better response until response becomes json parseable
+        '''
+        
+        # TO DO
+        # Construct this message better in order to make it better iteratively by
+        # _attempt_fix_and_generate recursive function
         message = UserMessage(
                     content=f"""
                         Fix the following json into correct format
@@ -109,7 +117,7 @@ class AgentOutputParser(BaseModel):
         attempt: int
     ) -> Dict[str, Any]:
         
-        """Attempt to fix JSON format using model generation."""
+        """Attempt to fix JSON format using model generation recursively."""
         if attempt >= max_retry:
             raise ValueError(
                 """

--- a/autochain/agent/structs.py
+++ b/autochain/agent/structs.py
@@ -75,7 +75,7 @@ class AgentOutputParser(BaseModel):
             )
             message = self._fix_message(clean_text)
             print('Check Message: ', message)
-            full_output: Generation = llm.generate(message).generations[0]
+            full_output: Generation = llm.generate([message]).generations[0]
             print("TEST: ", full_output)
             response = self._attempt_fix_and_generate(message, llm, max_retry, attempt=0)
 
@@ -83,14 +83,14 @@ class AgentOutputParser(BaseModel):
     
     @staticmethod
     def _fix_message(clean_text: str) -> UserMessage:
-        message = [UserMessage(
+        message = UserMessage(
                     content=f"""
                         Fix the following json into correct format
                         ```json
                         {clean_text}
                         ```
                         """
-                )]
+                )
         return message
         
     @staticmethod

--- a/autochain/agent/structs.py
+++ b/autochain/agent/structs.py
@@ -63,9 +63,8 @@ class AgentOutputParser(BaseModel):
     ) -> Dict[str, Any]:
         """Try to parse JSON response from the message content."""
         text = message.content
-        print('Message: ', message)
         clean_text = self._extract_json_text(text)
-        print('Clean text: ', clean_text)
+
         try:
             response = json.loads(clean_text)
         except Exception:
@@ -74,7 +73,6 @@ class AgentOutputParser(BaseModel):
                 Fore.RED
             )
             message = self._fix_message(clean_text)
-            print('Check Message: ', message)
             full_output: Generation = llm.generate([message]).generations[0]
             print("TEST: ", full_output)
             response = self._attempt_fix_and_generate(message, llm, max_retry, attempt=0)
@@ -131,9 +129,8 @@ class AgentOutputParser(BaseModel):
                 Fore.RED
             )
             clean_text = self._extract_json_text(full_output.message.content)
-            print("Clean Text: ", clean_text)
             message = self._fix_message(clean_text)
-            print('Message: ', message)
+            print("MESSAGE: ", message)
             return self._attempt_fix_and_generate(message, llm, max_retry, attempt=attempt + 1)
 
     @abstractmethod

--- a/autochain/agent/structs.py
+++ b/autochain/agent/structs.py
@@ -6,6 +6,7 @@ from typing import Union, Any, Dict, List
 from autochain.models.base import Generation
 
 from autochain.models.chat_openai import ChatOpenAI
+from autochain.models.base import BaseLanguageModel
 from pydantic import BaseModel
 
 from autochain.agent.message import BaseMessage, UserMessage
@@ -56,7 +57,7 @@ class AgentFinish(BaseModel):
 
 class AgentOutputParser(BaseModel):
     @staticmethod
-    def load_json_output(message: BaseMessage) -> Dict[str, Any]:
+    def load_json_output(message: BaseMessage, llm: BaseLanguageModel) -> Dict[str, Any]:
         """If the message contains a json response, try to parse it into dictionary"""
         text = message.content
         clean_text = ""
@@ -65,14 +66,13 @@ class AgentOutputParser(BaseModel):
             clean_text = text[text.index("{") : text.rindex("}") + 1].strip()
             response = json.loads(clean_text)
         except Exception:
-            llm = ChatOpenAI(temperature=0)
             message = [
                 UserMessage(
                     content=f"""Fix the following json into correct format
-```json
-{clean_text}
-```
-"""
+                        ```json
+                        {clean_text}
+                        ```
+                        """
                 )
             ]
             full_output: Generation = llm.generate(message).generations[0]


### PR DESCRIPTION
Hi,

I added HuggingFace `text-generation` models support, which was failing because of the use of `ChatOpenAI` (OpenAI API Key error occurs) when `ConversationalAgent` applies json output parsing through `ConvoJSONOutputParser` that uses `load_json_output`. To do that, instead of calling ChatOpenAI in the `except` part of the `load_json_output`, I am passing whatever llm model is given, either ChatOpenAI or HuggingFaceTextGenerationModel, just passing the provided llm inside to make it more general.

I also added `max_retry` to set the amount of retry that recursive function being applied to get the correct output that JSON parseable. `_fix_message` needs to be improved to get better responses from models each time it is called. I added it as TO DO as well as a comment there. 

After `max_retry` number is reached and if we couldn't get the proper json parseable response, I raised ValueError to inform user that selected open-source model is not good enough or is not able to generate json parseable output.

I checked this modified code with ChatOpenAI and it is working with no issue. But, there is a lot of things to do to improve and set the boundaries for the open-source model use. This may mean one needs to specify and allow some specific open-source models only. Also, some model optimizations can be applied.