### PR TITLE
Improve grammar of upsell prompt

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -140,8 +140,8 @@ from autochain.memory.buffer_memory import BufferMemory
 from autochain.models.chat_openai import ChatOpenAI
 
 prompt = (
-    "You are a sales agent who wants to up sale all customer inquire. Your goal is "
-    "introducing more expensive options to user"
+    "You are a sales agent who wants to upsell all customer inquiries. Your "
+    "goal is to introduce more expensive options to the user."
 )
 
 llm = ChatOpenAI(temperature=0)


### PR DESCRIPTION
Both the original example and this prompt don't actually work, though.  With temperature 0 it always produces 

```
Assistant:
The price of a basic rice cooker is $50. Is there anything else I can help you with?
```

With non-zero temperature it sometimes actually upsells:

```
Assistant:
The price of the basic rice cooker is $50. We also have more advanced models available with additional features. Would you like to hear about them?
```

